### PR TITLE
Add Socratic Seminar Lugano meetup for September 22, 2025

### DIFF
--- a/_posts/2025-09-22-socratic-seminar-lugano-1.md
+++ b/_posts/2025-09-22-socratic-seminar-lugano-1.md
@@ -1,0 +1,115 @@
+---
+layout: post
+type: socratic
+title: "Socratic Seminar Lugano 1"
+meetup: "https://www.meetup.com/bitcoin-meetup-switzerland/"
+---
+
+## Announcements
+Please join us for our next Socratic Seminar at [PoW.space in Lugano](https://pow.space/). A special thank you to our
+sponsor [Plan B Network](https://www.planb.network) and [PoW.space](https://pow.space),
+for refreshments and event space.
+
+**Location:** PoW.space, Lugano
+
+## Presentation
+-
+
+## Mailing Lists, Meetings and Bitcoin Optech
+### Mailing Lists
+#### [bitcoin-dev](https://lists.linuxfoundation.org/pipermail/bitcoin-dev)
+-
+
+#### [lightning-dev](https://lists.linuxfoundation.org/pipermail/lightning-dev)
+-
+
+#### [dlc-dev](https://mailmanlists.org/pipermail/dlc-dev)
+-
+
+### Meetings
+- [Bitcoin PR Review Club](https://bitcoincore.reviews)
+    -
+- [lnd PR Review Club](https://lnd.reviews/)
+    -
+- Bitcoin Core general developer meetings
+	-
+- Bitcoin Core wallet meetings
+	-
+- Lightning Specification meeting
+    -
+- Core Lightning Developer Call
+    -
+- dlc-specs meetings
+    -
+- Lightning specification meetings
+    -
+- Bitcoin Contracting Primitives Working Group
+	-
+
+### Optech
+-
+
+## Network Data
+-
+
+## CVEs and Research
+### Research
+-
+
+### InfoSec
+-
+
+## Pull Requests and repo updates
+### [Bitcoin Core](https://github.com/bitcoin/bitcoin)
+-
+
+### [BDK](https://github.com/bitcoindevkit/bdk)
+-
+
+### [HWI](https://github.com/bitcoin-core/HWI)
+-
+
+### [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
+-
+
+### [libsecp](https://github.com/bitcoin-core/secp256k1)
+-
+
+### [secp256k1-zkp](https://github.com/ElementsProject/secp256k1-zkp)
+-
+
+### [dlcspecs](https://github.com/discreetlogcontracts/dlcspecs)
+-
+
+### [Core Lightning](https://github.com/ElementsProject/lightning)
+-
+
+### [eclair](https://github.com/ACINQ/eclair/)
+-
+
+### [LDK](https://github.com/lightningdevkit/rust-lightning)
+-
+
+### [lnd](https://github.com/lightningnetwork/lnd)
+-
+
+### [BIPs](https://github.com/bitcoin/bips)
+-
+
+### [BLIPs](https://github.com/lightning/blips)
+-
+
+### [BOLTs](https://github.com/lightningnetwork/lightning-rfc)
+-
+
+## New Releases
+-
+
+## Events and Podcasts
+-
+
+## Mining
+-
+
+## Miscellaneous
+-


### PR DESCRIPTION
Created a new meetup page for the first Socratic Seminar in Lugano, scheduled for Monday, September 22, 2025. The event will be hosted at PoW.space in Lugano with sponsorship from Plan B Network and PoW.space.

This is just a placeholder, the list of events will came later