### PR TITLE
Add new topic to Socratic Seminar Lugano 3 post

### DIFF
--- a/_posts/2026-03-23-socratic-seminar-lugano-3.md
+++ b/_posts/2026-03-23-socratic-seminar-lugano-3.md
@@ -21,6 +21,7 @@ Join our [Telegram group](https://t.me/+QVmFPp07Gtw5MGM8)!
 - [Open-Source Agents Need to Get Serious About Payments (Matt Corallo)](https://x.com/TheBlueMatt/status/2026667191475777727?s=20)
 - [Claw Cash: one CLI for BTC, Lightning, Arkade, and stablecoins for agentic payments (tierotiero)](https://x.com/tierotiero/status/2024129431149686885?s=20)
 - [Ark as a channel factory: compressed liquidity management](https://delvingbitcoin.org/t/ark-as-a-channel-factory-compressed-liquidity-management-for-improved-payment-feasibility/2179)
+- [BOLT 12 Payer Proofs: prove your Lightning payment without revealing everything (Vincenzo Palazzo)](https://x.com/PalazzoVincenzo/status/2008178728187375896)
 - [BOLT issue #1314: zero-amount BOLT12 offers](https://github.com/lightning/bolts/issues/1314)
 - [BOLT PR #1316: reject zero-amount offers](https://github.com/lightning/bolts/pull/1316)
 - [LDK PR #4333: configurable blinded paths for BOLT12 offers](https://github.com/lightningdevkit/rust-lightning/pull/4333)


### PR DESCRIPTION
This pull request adds a new resource link to the seminar post, highlighting recent developments in Lightning payment proofs. The update is limited to the addition of a single link.

* Added a link to "[BOLT 12 Payer Proofs: prove your Lightning payment without revealing everything (Vincenzo Palazzo)]" to the `_posts/2026-03-23-socratic-seminar-lugano-3.md` file.